### PR TITLE
Changed simpleBuild to node to fix bug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-simpleBuild {
+node {
  
     env = [
         FOO : 42,


### PR DESCRIPTION
java.lang.NoSuchMethodError: No such DSL method 'simpleBuild' found among [archive, bat, build, catchError, checkout, checkpoint, deleteDir, dir, dockerFingerprintFrom, dockerFingerprintRun, echo, error, fileExists, git, input, isUnix, load, mail, node, parallel, properties, pwd, readFile, readTrusted, retry, sh, sleep, sshagent, stage, stash, step, timeout, tool, triggerRemoteJob, unarchive, unstash, waitUntil, withCredentials, withDockerContainer, withDockerRegistry, withDockerServer, withEnv, wrap, writeFile, ws]
    at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:108)
